### PR TITLE
Resolve mvn issues

### DIFF
--- a/flink-libraries/flink-python/src/main/java/org/apache/flink/python/api/PythonPlanBinder.java
+++ b/flink-libraries/flink-python/src/main/java/org/apache/flink/python/api/PythonPlanBinder.java
@@ -78,7 +78,7 @@ public class PythonPlanBinder {
 	public static String FLINK_PYTHON3_BINARY_PATH =
 		GlobalConfiguration.loadConfiguration().getString(FLINK_PYTHON3_BINARY_KEY, "python3");
 
-	private static final Random r = new Random();
+	public static final Random r = new Random();
 
 	public static final String FLINK_PYTHON_FILE_PATH = System.getProperty("java.io.tmpdir") + File.separator + "flink_plan";
 	private static final String FLINK_PYTHON_REL_LOCAL_PATH = File.separator + "resources" + File.separator + "python";
@@ -137,7 +137,7 @@ public class PythonPlanBinder {
 
 		try {
 			String tmpPath = FLINK_PYTHON_FILE_PATH + r.nextInt();
-			prepareFiles(tmpPath, Arrays.copyOfRange(args, 0, split == 0 ? args.length : split));
+			prepareFiles(FULL_PATH, tmpPath, Arrays.copyOfRange(args, 0, split == 0 ? args.length : split));
 			startPython(tmpPath, Arrays.copyOfRange(args, split == 0 ? args.length : split + 1, args.length));
 			receivePlan();
 
@@ -164,10 +164,10 @@ public class PythonPlanBinder {
 	 * @throws IOException
 	 * @throws URISyntaxException
 	 */
-	private void prepareFiles(String tempFilePath, String... filePaths) throws IOException, URISyntaxException {
+	public static void prepareFiles(String libPath, String tempFilePath, String... filePaths) throws IOException, URISyntaxException {
 		//Flink python package
 		clearPath(tempFilePath);
-		FileCache.copy(new Path(FULL_PATH), new Path(tempFilePath), false);
+		FileCache.copy(new Path(libPath), new Path(tempFilePath), false);
 
 		//plan file		
 		copyFile(filePaths[0], tempFilePath, FLINK_PYTHON_PLAN_NAME);

--- a/flink-libraries/flink-python/src/test/python/org/apache/flink/python/api/ut_pyflink.py
+++ b/flink-libraries/flink-python/src/test/python/org/apache/flink/python/api/ut_pyflink.py
@@ -35,10 +35,6 @@ def parse_args():
 	parser.add_argument('--python-path', dest="python_path", metavar="PATH", default=None,
 						help="python search path to use")
 
-	parser.add_argument('--mvn-mode', dest="mvn_mode", action="store_true", default=False,
-						help="Intended for internal use only (DO NOT USE UNLESS YOU KNOW WAHT YOU ARE DOING) " +
-							 "This flag indicate that the script is called by maven/java editor")
-
 	parser.add_argument('--run-mode', dest="run_mode", action="store_true", default=False,
 						help="Intended for internal use only (DO NOT USE UNLESS YOU KNOW WAHT YOU ARE DOING) " +
 							 "This flag indicate that the script is called the second time to actually run the tests")
@@ -54,29 +50,14 @@ def parse_args():
 	return local_options
 
 
-# The python path argument should be present in the run mode when the python file/plane is run in a different
-# location. The assumption is that the path provided is absolute path
-def fix_python_path(python_path):
-	if python_path is not None:
-		path_list = options.python_path.split(":")
-		for p in path_list:
-			sys.path.append(p)
-
-
 # This code should run before any other piece of code using the flink python stuff
 options = parse_args()
 if options.verbose:
 	print("In first main section")
-fix_python_path(options.python_path)
 
 
-# Flink python testing imports
-if options.mvn_mode:
-	from subprocess_test import SubprocessTestCase
-	from utils import Id, Verify
-else:
-	from utils.subprocess_test import SubprocessTestCase
-	from utils.utils import Id, Verify
+from utils.subprocess_test import SubprocessTestCase
+from utils.utils import Id, Verify
 
 # Flink python imports
 from flink.plan.Environment import get_environment


### PR DESCRIPTION
* Refactored ```PythonPlanBinder#prepareFiles()``` to be static.
* Reworked ```findUtilsFile``` to return utils folder instead
  * subsumed ```findSubproessTestCaseFile()```
* Fixed ```findUnitTestFiles()``` on Windows, along with simpler file name extraction
* python library, test file and utils are copied to tmp location within ```getFileTestCasesAndMethods()```
  * removed PYTHONPATH modifications as they are now unnecessary
  * removed --mvn-mode parameter

I hope these changes fix the issues that you encountered.